### PR TITLE
Fix exit-code generation on test failure.

### DIFF
--- a/src/DEMAConsulting.VHDLTest/Context.cs
+++ b/src/DEMAConsulting.VHDLTest/Context.cs
@@ -167,8 +167,15 @@ public sealed class Context : IDisposable
     ///     Write an error message to output
     /// </summary>
     /// <param name="message">Error message to write</param>
-    public void WriteError(string message)
+    public void WriteError(string? message)
     {
+        // Increment the number of errors
+        Errors++;
+
+        // Skip writing if no message provided
+        if (message == null)
+            return;
+
         // Write to the console unless silent
         if (!Silent)
         {
@@ -179,9 +186,6 @@ public sealed class Context : IDisposable
 
         // Write to the log if specified
         _log?.WriteLine(message);
-
-        // Increment the number of errors
-        Errors++;
     }
 
     /// <summary>

--- a/src/DEMAConsulting.VHDLTest/Program.cs
+++ b/src/DEMAConsulting.VHDLTest/Program.cs
@@ -123,7 +123,7 @@ public static class Program
 
             // If we got failures then exit with an error code
             if (!context.ExitZero && results.Fails.Any())
-                Environment.ExitCode = 1;
+                context.WriteError(null);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/DEMAConsulting.VHDLTest/Simulators/MockSimulator.cs
+++ b/src/DEMAConsulting.VHDLTest/Simulators/MockSimulator.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) 2024 DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text;
+using DEMAConsulting.VHDLTest.Results;
+using DEMAConsulting.VHDLTest.Run;
+
+namespace DEMAConsulting.VHDLTest.Simulators;
+
+/// <summary>
+///     Mock Simulator Class
+/// </summary>
+public sealed class MockSimulator : Simulator
+{
+    /// <summary>
+    /// Compile processor
+    /// </summary>
+    public static readonly RunProcessor CompileProcessor = new(
+        [
+            RunLineRule.Create(RunLineType.Info, "Info:"),
+            RunLineRule.Create(RunLineType.Warning, "Warning:"),
+            RunLineRule.Create(RunLineType.Error, "Error:")
+        ]
+    );
+
+    /// <summary>
+    /// Test processor
+    /// </summary>
+    public static readonly RunProcessor TestProcessor = new(
+        [
+            RunLineRule.Create(RunLineType.Info, "Info:"),
+            RunLineRule.Create(RunLineType.Warning, "Warning:"),
+            RunLineRule.Create(RunLineType.Error, "Failure:"),
+            RunLineRule.Create(RunLineType.Error, "Error:")
+        ]
+    );
+
+    /// <summary>
+    ///     Mock simulator instance
+    /// </summary>
+    public static readonly MockSimulator Instance = new();
+
+    /// <summary>
+    ///     Initializes a new instance of the Mock simulator
+    /// </summary>
+    private MockSimulator() : base("Mock", null)
+    {
+    }
+
+    /// <inheritdoc />
+    public override RunResults Compile(Context context, Options options)
+    {
+        // Log the start of the compile command
+        context.WriteVerboseLine("Starting Mock compile...");
+
+        // Simulate compiling, and produce output
+        var output = new StringBuilder();
+        var exitCode = 0;
+        foreach (var file in options.Config.Files)
+        {
+            // Use filename to determine type of result
+            if (file.Contains("_error_"))
+            {
+                // File produces error and compile fails
+                output.AppendLine($"Error: {file}");
+                exitCode = 1;
+            }
+            else if (file.Contains("_warning_"))
+            {
+                // File produces warning
+                output.AppendLine($"Warning: {file}");
+            }
+            else if (file.Contains("_info_"))
+            {
+                // File produces info
+                output.AppendLine($"Info: {file}");
+            }
+            else
+            {
+                // File produces no special output
+                output.AppendLine($"Compiled {file}");
+            }
+        }
+
+        // Return the compile results
+        return CompileProcessor.Parse(
+            DateTime.Now,
+            DateTime.Now,
+            output.ToString(),
+            exitCode);
+    }
+
+    /// <inheritdoc />
+    public override TestResult Test(Context context, Options options, string test)
+    {
+        // Log the start of the compile command
+        context.WriteVerboseLine($"Starting Mock test {test}...");
+
+        // Simulate test, and produce output
+        var output = new StringBuilder();
+        var exitCode = 0;
+
+        // Add warning if desired
+        if (test.Contains("_warning_"))
+            output.AppendLine($"Warning: {test}");
+
+        // Add info if desired
+        if (test.Contains("_info_"))
+            output.AppendLine($"Info: {test}");
+
+        // Use test name to determine type of result
+        if (test.Contains("_error_"))
+        {
+            output.AppendLine($"Error: {test}");
+            exitCode = 1;
+        }
+        else if (test.Contains("_fail_"))
+        {
+            output.AppendLine($"Failure: {test}");
+        }
+        else
+        {
+            output.AppendLine($"Passed: {test}");
+        }
+
+        // Return the test results
+        return new TestResult(
+            test,
+            test,
+            TestProcessor.Parse(
+                DateTime.Now,
+                DateTime.Now,
+                output.ToString(),
+                exitCode));
+    }
+}

--- a/src/DEMAConsulting.VHDLTest/Simulators/SimulatorFactory.cs
+++ b/src/DEMAConsulting.VHDLTest/Simulators/SimulatorFactory.cs
@@ -44,6 +44,10 @@ public static class SimulatorFactory
     /// <returns>Simulator instance or null</returns>
     public static Simulator? Get(string? name = null)
     {
+        // Only return the mock simulator if explicitly requested
+        if (name == "mock")
+            return MockSimulator.Instance;
+
         // If the simulator is specified then use it
         if (name != null)
             return Array.Find(Simulators, s => s.SimulatorName.Equals(name, StringComparison.InvariantCultureIgnoreCase));

--- a/test/DEMAConsulting.VHDLTest.Tests/TestExitCode.cs
+++ b/test/DEMAConsulting.VHDLTest.Tests/TestExitCode.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) 2023 DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DEMAConsulting.VHDLTest.Tests;
+
+/// <summary>
+/// Tests for exit code
+/// </summary>
+[TestClass]
+public class TestExitCode
+{
+    /// <summary>
+    /// Test non-zero exit code with compile errors
+    /// </summary>
+    [TestMethod]
+    public void TestCompileError()
+    {
+        try
+        {
+            // Write a config file
+            File.WriteAllText("test_compile_error.yaml",
+                """
+                files:
+                 - file_error_test.vhd
+                
+                tests:
+                 - file_error_test_tb
+                """
+                );
+
+            // Run the application using the mock simulator
+            var exitCode = Runner.Run(
+                out _,
+                "dotnet",
+                "DEMAConsulting.VHDLTest.dll",
+                "--simulator", "mock",
+                "--config", "test_compile_error.yaml");
+
+            // Verify error reported
+            Assert.AreNotEqual(0, exitCode);
+        }
+        finally
+        {
+            File.Delete("test_compile_error.yaml");
+        }
+    }
+
+    /// <summary>
+    /// Test non-zero exit code with test-execution errors
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionError()
+    {
+        try
+        {
+            // Write a config file
+            File.WriteAllText("test_execution_error.yaml",
+                """
+                files:
+                 - file_test.vhd
+
+                tests:
+                 - file_error_test_tb
+                """
+            );
+
+            // Run the application using the mock simulator
+            var exitCode = Runner.Run(
+                out _,
+                "dotnet",
+                "DEMAConsulting.VHDLTest.dll",
+                "--simulator", "mock",
+                "--config", "test_execution_error.yaml");
+
+            // Verify error reported
+            Assert.AreNotEqual(0, exitCode);
+        }
+        finally
+        {
+            File.Delete("test_execution_error.yaml");
+        }
+    }
+
+    /// <summary>
+    /// Test non-zero exit code with test-execution errors
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionErrorSuppress()
+    {
+        try
+        {
+            // Write a config file
+            File.WriteAllText("test_execution_error.yaml",
+                """
+                files:
+                 - file_test.vhd
+
+                tests:
+                 - file_error_test_tb
+                """
+            );
+
+            // Run the application using the mock simulator
+            var exitCode = Runner.Run(
+                out _,
+                "dotnet",
+                "DEMAConsulting.VHDLTest.dll",
+                "--simulator", "mock",
+                "--config", "test_execution_error.yaml",
+                "--exit-0");
+
+            // Verify error suppressed
+            Assert.AreEqual(0, exitCode);
+        }
+        finally
+        {
+            File.Delete("test_execution_error.yaml");
+        }
+    }
+
+    /// <summary>
+    /// Test non-zero exit code with test-execution errors
+    /// </summary>
+    [TestMethod]
+    public void TestExecutionPassed()
+    {
+        try
+        {
+            // Write a config file
+            File.WriteAllText("test_execution_pass.yaml",
+                """
+                files:
+                 - file_test.vhd
+
+                tests:
+                 - file_test_tb
+                """
+            );
+
+            // Run the application using the mock simulator
+            var exitCode = Runner.Run(
+                out _,
+                "dotnet",
+                "DEMAConsulting.VHDLTest.dll",
+                "--simulator", "mock",
+                "--config", "test_execution_pass.yaml");
+
+            // Verify no error
+            Assert.AreEqual(0, exitCode);
+        }
+        finally
+        {
+            File.Delete("test_execution_pass.yaml");
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #24 by changing how test-failure errors are reported using the new context mechanism. Additionally a mock simulator was added and unit tests for correct exit-code behavior.