### PR TITLE
This PR adds support for '--result' argument.

### DIFF
--- a/src/DEMAConsulting.VHDLTest/Context.cs
+++ b/src/DEMAConsulting.VHDLTest/Context.cs
@@ -267,6 +267,7 @@ public sealed class Context : IDisposable
                     break;
 
                 case "-r":
+                case "--result":
                 case "--results":
                     // Handle results file
                     resultsFile = GetArgument(e, "Missing results file name");


### PR DESCRIPTION
This PR implements #29 by allowing for `--result` as well as `--results` argument.